### PR TITLE
Fixing undefined method `tag_options'

### DIFF
--- a/lib/wice/wice_grid_core_ext.rb
+++ b/lib/wice/wice_grid_core_ext.rb
@@ -113,7 +113,11 @@ module ActionView #:nodoc:
   module Helpers #:nodoc:
     module TagHelper #:nodoc:
       def public_tag_options(options, escape = true) #:nodoc:
-        tag_options(options, escape)
+        if respond_to?(:tag_options)
+          tag_options(options, escape)
+        else
+          tag_builder.tag_options(options, escape)
+        end
       end
     end
   end


### PR DESCRIPTION
I needed this change for work on rails 5.1

That solution has made from another user.
Thanks for your work.
