### PR TITLE
Work around columns being frozen

### DIFF
--- a/lib/wice/table_column_matrix.rb
+++ b/lib/wice/table_column_matrix.rb
@@ -54,7 +54,7 @@ module Wice
     end
 
     def init_columns_of_table(model) #:nodoc:
-      self[model] = HashWithIndifferentAccess.new(model.columns.index_by(&:name))
+      self[model] = HashWithIndifferentAccess.new(model.columns.map(&:dup).index_by(&:name))
       @by_table_names[model.table_name] = self[model]
       self[model].each_value { |c| c.model = model }
     end


### PR DESCRIPTION
Hi! I started using your fork and the `fix/all` branch for a Rails 6 upgrade of a legacy application I was working on. Mostly it worked great, but I had one issue with frozen activerecord columns.

Since https://github.com/rails/rails/pull/39463, many AR methods return frozen results. Since the code here intends to modify the columns, we need to dup them.